### PR TITLE
Thanks for the useful and well written library. So updates for your consideration.

### DIFF
--- a/examples/tempest_rapid_wind/tempest_rapid_wind.cpp
+++ b/examples/tempest_rapid_wind/tempest_rapid_wind.cpp
@@ -26,7 +26,7 @@ void setup(){
         delay(500);
     }
 
-    // Begin listing for UDP WeatherFlow API packets
+    // Begin listening for UDP WeatherFlow API packets
     WF.Begin();
 }
 

--- a/include/wf.h
+++ b/include/wf.h
@@ -253,7 +253,7 @@ class wfDeviceStatus{
         unsigned int uiFirmwareVersion;
         time_t ulTimeStamp;
         time_t ulUptime;
-        unsigned int uiVoltage;
+        float fVoltage;
         int iRssi;
         int iHubRssi;
         unsigned int uiSensorStatus;
@@ -283,7 +283,7 @@ class wfDeviceStatus{
         unsigned int FirmwareVersion(void);
         time_t TimeStamp(void);
         time_t Uptime(void);
-        unsigned int Voltage(void);
+        float Voltage(void);
         int RSSI(void);
         int HubRSSI(void);
         unsigned int SensorStatus(void);
@@ -293,7 +293,7 @@ class wfDeviceStatus{
 class wfHubStatus{
     private:
         String strHubSerialNumber;
-        String strFirmwareVersion;
+        unsigned int uiFirmwareVersion;
         time_t ulTimeStamp;
         time_t ulUptime;
         int iRssi;
@@ -304,7 +304,7 @@ class wfHubStatus{
         wfHubStatus();
         bool ParseMsg(JsonDocument&);
         String HubSerialNumber(void);
-        String FirmwareVersion(void);
+        unsigned int FirmwareVersion(void);
         time_t TimeStamp(void);
         time_t Uptime(void);
         String ResetFlags(void);

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@ platform = espressif32
 board = tinypico
 framework = arduino
 lib_deps = 
-	bblanchon/ArduinoJson@^6.18.0
+	bblanchon/ArduinoJson@^6
 build_flags = 
 	-D BOARD_HAS_PSRAM
 	-mfix-esp32-psram-cache-issue

--- a/src/wf.cpp
+++ b/src/wf.cpp
@@ -76,6 +76,11 @@ bool wfRainStartEvent::ParseMsg(JsonDocument& jsonMsg){
         valid = false;
         return false;
     };
+
+    // Station info (serial numbers)
+    strSerialNumber = jsonMsg["serial_number"].as<String>();
+    strHubSerialNumber = jsonMsg["hub_sn"].as<String>();
+
     // Parse the message array
     uint8_t count = 0; 
     for( JsonVariant RainStart : jsonMsg["evt"].as<JsonArray>() ){
@@ -129,6 +134,11 @@ bool wfLightningStrikeEvent::ParseMsg(JsonDocument& jsonMsg){
         valid = false;
         return false;
     };
+
+    // Station info (serial numbers)
+    strSerialNumber = jsonMsg["serial_number"].as<String>();
+    strHubSerialNumber = jsonMsg["hub_sn"].as<String>();
+
     // Parse the message array
     uint8_t count = 0; 
     for( JsonVariant LightningStrike : jsonMsg["evt"].as<JsonArray>() ){
@@ -222,6 +232,11 @@ bool wfRapidWind::ParseMsg(JsonDocument& jsonMsg){
         valid = false;
         return false;
     };
+
+    // Station info (serial numbers)
+    strSerialNumber = jsonMsg["serial_number"].as<String>();
+    strHubSerialNumber = jsonMsg["hub_sn"].as<String>();
+
     // Parse the message array
     uint8_t count = 0; 
     for( JsonVariant RapidWind : jsonMsg["ob"].as<JsonArray>() ){
@@ -945,7 +960,7 @@ wfDeviceStatus::wfDeviceStatus(){
     uiFirmwareVersion = 0;
     ulTimeStamp = 0;
     ulUptime = 0;
-    uiVoltage = 0;
+    fVoltage = 0;
     iRssi = -999;
     iHubRssi = -999;
     uiSensorStatus = 0;
@@ -959,7 +974,7 @@ bool wfDeviceStatus::ParseMsg(JsonDocument& jsonMsg){
     strHubSerialNumber = jsonMsg["hub_sn"].as<String>();
     ulTimeStamp = jsonMsg["timestamp"].as<time_t>();
     ulUptime = jsonMsg["uptime"].as<time_t>();
-    uiVoltage = jsonMsg["voltage"].as<unsigned int>();
+    fVoltage = jsonMsg["voltage"].as<float>();
     uiFirmwareVersion = jsonMsg["firmware_revision"].as<unsigned int>();
     iRssi = jsonMsg["rssi"].as<int>();
     iHubRssi = jsonMsg["hub_rssi"].as<int>();
@@ -987,8 +1002,8 @@ time_t wfDeviceStatus::TimeStamp(void){ return ulTimeStamp; };
 // Station uptime in seconds.
 time_t wfDeviceStatus::Uptime(void){ return ulUptime; };
 
-// Station battery voltage as unsigned integer.
-unsigned int wfDeviceStatus::Voltage(void){ return uiVoltage; };
+// Station battery voltage as float.
+float wfDeviceStatus::Voltage(void){ return fVoltage; };
 
 // Station wireless RSSI as integer.
 int wfDeviceStatus::RSSI(void){ return iRssi; };
@@ -1011,7 +1026,7 @@ wfDeviceStatus::DebugStatus wfDeviceStatus::Debug(void){ return static_cast<Debu
 /  *********************************************/
 wfHubStatus::wfHubStatus(){
     strHubSerialNumber.clear();
-    strFirmwareVersion.clear();
+    uiFirmwareVersion = 0;
     ulTimeStamp = 0;
     ulUptime = 0;
     iRssi = -999;
@@ -1023,7 +1038,7 @@ wfHubStatus::wfHubStatus(){
 // Parse the JSON message for the hub status data.
 bool wfHubStatus::ParseMsg(JsonDocument& jsonMsg){
     strHubSerialNumber = jsonMsg["serial_number"].as<String>();
-    strFirmwareVersion = jsonMsg["firmware_revision"].as<String>();
+    uiFirmwareVersion = jsonMsg["firmware_revision"].as<unsigned int>();
     ulTimeStamp = jsonMsg["timestamp"].as<time_t>();
     ulUptime = jsonMsg["uptime"].as<time_t>();
     iRssi = jsonMsg["rssi"].as<int>();
@@ -1036,8 +1051,8 @@ bool wfHubStatus::ParseMsg(JsonDocument& jsonMsg){
 // Hub serial number as String.
 String wfHubStatus::HubSerialNumber(void){ return strHubSerialNumber; };
 
-// Hub firmware version as String.
-String wfHubStatus::FirmwareVersion(void){ return strFirmwareVersion; };
+// Hub firmware version as unsigned int.
+unsigned int wfHubStatus::FirmwareVersion(void){ return uiFirmwareVersion; };
 
 // Status time stamp in Epoch seconds.
 time_t wfHubStatus::TimeStamp(void){ return ulTimeStamp; };


### PR DESCRIPTION
Corrected comment spelling listing to listening in tempest_rapid_wind.cpp

Changed Voltage in wfDeviceStatus from unsigned integer to float to accommodate value returned in UDP packet

Added JSON parsing for device serial number and hub serial number to wfRainStartEvent, wfLightningStrikeEvent and wfRapidWind

Changed FirmwareVersion type in wfHubStatus from String to unsigned int to be consistent with FirmwareVersion in Air, Sky and Tempest classes